### PR TITLE
Support global group

### DIFF
--- a/lib/hook.ex
+++ b/lib/hook.ex
@@ -101,7 +101,8 @@ defmodule Hook do
   @callback assert(group()) :: :ok
   @callback callback(module(), function_name :: atom(), fun(), callback_opts()) :: :ok
   @callback callbacks(group()) :: %{resolved: [], unresolved: [{count(), pid(), function()}]}
-  @callback fallback(dest :: group(), src :: group()) :: :ok
+  @callback fallback(dest :: group(), src :: group()) ::
+              :ok | {:error, {:invalid_group, :destination | :source}}
   @callback fetch!(any(), group()) :: any()
   @callback fetch(key(), group()) :: {:ok, any()} | :error
   @callback get(key(), default :: any(), group()) :: {:ok, any()} | :error
@@ -209,6 +210,8 @@ defmodule Hook do
 
   @doc """
   Prepend `group` to the calling process' fallbacks.
+
+  **NOTE:** `:global` cannot be used as a `src_group`.
   """
   defdelegate fallback(src_group \\ self(), dest_group), to: Server
 

--- a/lib/hook/server.ex
+++ b/lib/hook/server.ex
@@ -32,7 +32,11 @@ defmodule Hook.Server do
             __fetch__(ancestors, match_fun)
 
           :error ->
-            :error
+            if group == :global do
+              :error
+            else
+              __fetch__([:global], match_fun)
+            end
         end
 
       {:error, groups} ->
@@ -78,6 +82,8 @@ defmodule Hook.Server do
   end
 
   @impl Hook
+  def fallback(:global, _), do: {:error, {:invalid_group, :source}}
+
   def fallback(src, dest), do: GenServer.call(__MODULE__, {:fallback, {src, dest}})
 
   @impl Hook


### PR DESCRIPTION
To make it easier to define mappings for unnamed pids whose ancestors
are non-trivial to identify.